### PR TITLE
Bug 1531871 - do a *much* better job of handling old and new schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mocha": "6.0.2"
   },
   "dependencies": {
-    "ajv": "^6.9.2",
+    "ajv": "^6.10.0",
     "debug": "^4.1.1",
     "fast-azure-storage": "^2.3.1",
     "lodash": "^4.17.11",

--- a/src/datablob.js
+++ b/src/datablob.js
@@ -48,9 +48,9 @@ class DataBlob {
     let result = await this.container.validate(content, this.version ? this.version:this.container.schemaVersion);
     if (!result.valid) {
       debug(`Failed to validate the blob content against schema with id:
-          ${this.container.schema.$id}, errors: ${result.errors}`);
-      let error = new SchemaValidationError(`Failed to validate the blob content against schema with id:
-                                            ${this.container.schema.$id}`);
+          ${this.container.schema.id}, errors: ${result.errors}`);
+      let error = new SchemaValidationError(
+        `Failed to validate the blob content against schema with id ${this.container.schema.id}: ${result.errorsText}`);
       error.content = content;
       error.validationErrors = result.errors;
       throw error;

--- a/test/schemaversions_test.js
+++ b/test/schemaversions_test.js
@@ -1,0 +1,69 @@
+const assume = require('assume');
+const azure = require('fast-azure-storage');
+const debug = require('debug')('azure-blob-storage-test:data-container');
+const {schema, credentials} = require('./helpers');
+const uuid = require('uuid');
+const {DataContainer, DataBlockBlob, AppendDataBlob} = require('../');
+
+suite('Schema Versioning', () => {
+  const containerNamePrefix = 'test';
+  let onTeardown = null;
+
+  teardown(async function() {
+    if (onTeardown) {
+      await onTeardown();
+      onTeardown = null;
+    }
+  });
+
+  const setupContainer = async (credentials) => {
+    const containerName = `data-container-test${uuid.v4()}`;
+    const blobService = new azure.Blob(credentials);
+    await blobService.createContainer(containerName);
+
+    onTeardown = async () => {
+      await blobService.deleteContainer(containerName);
+    };
+
+    return {blobService, containerName};
+  };
+
+  test('create an instance of data container with a schema from before v4.0.0', async () => {
+    const {blobService, containerName} = await setupContainer(credentials);
+
+    // write out an "old-style" schema.  Notably, this old schema has 'id', not '$id'..
+    const schema = {
+      $schema: 'http://json-schema.org/draft-06/schema#',
+      id: `http://${credentials.accountId}.blob.core.windows.net/${containerName}/.schema.v1.json`,
+      title: 'test json schema',
+      type: 'object',
+      properties: {
+        value: {
+          type: 'integer',
+        },
+      },
+      additionalProperties: false,
+      required: ['value'],
+    };
+    await blobService.putBlob(containerName, '.schema.v1', {type: 'BlockBlob'}, JSON.stringify(schema));
+
+    // also write out a data value to fetch
+    const content = {version: 1, content: {value: 13}};
+    await blobService.putBlob(containerName, 'some-data', {type: 'BlockBlob'}, JSON.stringify(content));
+
+    const container = new DataContainer({credentials, schema, containerName});
+    await container.init();
+
+    const blob = await container.load('some-data');
+
+    const before = await blob.load();
+    assume(before.value).to.equal(13);
+
+    await blob.modify(blob => {
+      blob.value = 14;
+    });
+
+    const after = await blob.load();
+    assume(after.value).to.equal(14);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,7 +33,17 @@ acorn@^6.0.7:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
-ajv@^6.9.1, ajv@^6.9.2:
+ajv@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
+  integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
+  dependencies:
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.9.1:
   version "6.9.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.9.2.tgz#4927adb83e7f48e5a32b45729744c71ec39c9c7b"
   integrity sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==


### PR DESCRIPTION
This uses a "canonical" schema, always with `$id`, and performs a deep
comparison rather than assuming `JSON.stringify` produces stable output
(it doesn't).

This also adds a test that begins with an old (using `id`) schema and
modifies a value.  I confirmed that, without canonical schemas, this
test fails.

Other fixes:

 * report schema errors as text
 * _cacheSchema -> _checkSchema, since that is all it does